### PR TITLE
session contract: accountantId -> hermesId

### DIFF
--- a/src/session/session.spec.ts
+++ b/src/session/session.spec.ts
@@ -12,7 +12,7 @@ describe('TequilapiClient DTO', () => {
     id: 'id1',
     direction: 'Provided',
     consumerId: '0x1',
-    accountantId: '0x2',
+    hermesId: '0x2',
     providerId: '0x3',
     serviceType: 'openvpn',
     providerCountry: 'MU',

--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -21,7 +21,7 @@ export interface Session {
   id: string
   direction: SessionDirection
   consumerId: string
-  accountantId: string
+  hermesId: string
   providerId: string
   serviceType: string
   providerCountry: string
@@ -38,7 +38,7 @@ export function parseSession(data: any): Session {
     { name: 'id', type: 'string' },
     { name: 'direction', type: 'string' },
     { name: 'consumerId', type: 'string' },
-    { name: 'accountantId', type: 'string' },
+    { name: 'hermesId', type: 'string' },
     { name: 'providerId', type: 'string' },
     { name: 'serviceType', type: 'string' },
     { name: 'providerCountry', type: 'string' },

--- a/src/tequilapi-client.spec.ts
+++ b/src/tequilapi-client.spec.ts
@@ -733,7 +733,7 @@ describe('HttpTequilapiClient', () => {
             id: '30f610a0-c096-11e8-b371-ebde26989839',
             direction: 'Provided',
             consumer_id: '0x1000FACE',
-            accountant_id: '',
+            hermes_id: '',
             provider_id: '',
             service_type: '',
             provider_country: '',


### PR DESCRIPTION
This change came from `master` merge to `v3`. [LINK](https://github.com/mysteriumnetwork/node/blob/e42951a5408cb49612ded8697b1c8666f42a97cd/tequilapi/contract/session.go#L122)

