### PR TITLE
Possible to rebuild library then used inside node_modules/mysterium-vpn-js

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,5 @@
 {
+  "root": true,
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "project": "./tsconfig.json",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -11,6 +11,9 @@
     "lib": ["es2015"],
     "outDir": "lib",
     "strict": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "typeRoots": [
+      "./node_modules/@types/"
+    ]
   }
 }


### PR DESCRIPTION
Allows building this library then it's added into projects like:
```
"dependencies": {
    ...
    "mysterium-vpn-js": "https://github.com/mysteriumnetwork/mysterium-vpn-js.git#feature/allow-nested-builds",
    ...
}
```