### PR TITLE
Introduce ProviderAPI

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -109,4 +109,13 @@ export { EntertainmentEstimateQuery, EntertainmentEstimateResponse } from './pay
 export { ReferralTokenResponse } from './referral'
 export { IdentityBeneficiaryResponse } from './identity/beneficiary'
 
+export {
+  ProviderAPI,
+  QueryRange,
+  SessionsRequest,
+  SessionsV2Response,
+  SessionV2,
+  SessionV2CountResponse,
+} from './provider'
+
 export default tequilapi

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2022 BlockDev AG
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import { HttpInterface } from '../http/interface'
+import { Tokens } from '../common/tokens'
+
+export class ProviderAPI {
+  private http: HttpInterface
+
+  constructor(http: HttpInterface) {
+    this.http = http
+  }
+
+  public async sessions(query: SessionsRequest = { range: '1d' }): Promise<SessionsV2Response> {
+    return await this.http.get('/node/provider/sessions', query)
+  }
+
+  public async sessionCount(
+    query: SessionsRequest = { range: '1d' }
+  ): Promise<SessionV2CountResponse> {
+    return await this.http.get('/node/provider/sessions-count', query)
+  }
+}
+
+export type QueryRange = '1d' | '7d' | '30d' | string
+
+export interface SessionsRequest {
+  range?: QueryRange
+}
+
+export interface SessionsV2Response {
+  sessions: SessionV2[]
+}
+
+export interface SessionV2 {
+  id: string
+  consumerCountry: string
+  serviceType: string
+  durationSeconds: number
+  startedAt: string
+  earnings: Tokens
+  transferredBytes: number
+}
+
+export interface SessionV2CountResponse {
+  count: number
+}

--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -8,16 +8,25 @@
 import { validate, validateMultiple } from '../fmt/validation'
 import { Pageable, PaginationQuery, parsePageable } from '../common/pageable'
 
+/**
+ * @deprecated use ProviderAPI
+ */
 export enum SessionStatus {
   NEW = 'New',
   COMPLETED = 'Completed',
 }
 
+/**
+ * @deprecated use ProviderAPI
+ */
 export enum SessionDirection {
   CONSUMED = 'Consumed',
   PROVIDED = 'Provided',
 }
 
+/**
+ * @deprecated use ProviderAPI
+ */
 export interface Session {
   id: string
   direction: SessionDirection
@@ -54,6 +63,9 @@ export function parseSession(data: any): Session {
   return data
 }
 
+/**
+ * @deprecated use ProviderAPI
+ */
 export interface SessionStats {
   count: number
   countConsumers: number
@@ -75,6 +87,9 @@ export function parseSessionStats(data: any): SessionStats {
   return data
 }
 
+/**
+ * @deprecated use ProviderAPI
+ */
 export interface SessionQuery {
   dateFrom?: string
   dateTo?: string
@@ -86,8 +101,14 @@ export interface SessionQuery {
   status?: SessionStatus
 }
 
+/**
+ * @deprecated use ProviderAPI
+ */
 export interface SessionListQuery extends PaginationQuery, SessionQuery {}
 
+/**
+ * @deprecated use ProviderAPI
+ */
 export type SessionListResponse = Pageable<Session>
 
 export function parseSessionListResponse(responseData: any): SessionListResponse {
@@ -96,6 +117,9 @@ export function parseSessionListResponse(responseData: any): SessionListResponse
   return response
 }
 
+/**
+ * @deprecated use ProviderAPI
+ */
 export interface SessionStatsAggregatedResponse {
   stats: SessionStats
 }
@@ -108,6 +132,9 @@ export function parseSessionStatsAggregatedResponse(data: any): SessionStatsAggr
   }
 }
 
+/**
+ * @deprecated use ProviderAPI
+ */
 export interface SessionStatsDailyResponse {
   items: {
     [date: string]: SessionStats

--- a/src/tequilapi-client.ts
+++ b/src/tequilapi-client.ts
@@ -72,6 +72,7 @@ import { FilterPresetsResponse } from './proposal/filter-preset'
 import { EntertainmentEstimateQuery, EntertainmentEstimateResponse } from './payment/entertainment'
 import { NatTypeResponse, parseNatTypeResponse } from './nat/type'
 import { WithdrawRequest } from './transactor/withdraw'
+import { ProviderAPI } from './provider'
 
 export const TEQUILAPI_URL = 'http://127.0.0.1:4050'
 export const pathConfig = 'config'
@@ -134,8 +135,17 @@ export interface BaseTequilapiClient {
   serviceStart(request: ServiceStartRequest, timeout?: number): Promise<ServiceInfo>
   serviceStop(serviceId: string): Promise<void>
 
+  /**
+   * @deprecated use ProviderAPI
+   */
   sessions(query?: SessionListQuery): Promise<SessionListResponse>
+  /**
+   * @deprecated use ProviderAPI
+   */
   sessionStatsAggregated(query?: SessionQuery): Promise<SessionStatsAggregatedResponse>
+  /**
+   * @deprecated use ProviderAPI
+   */
   sessionStatsDaily(query?: SessionQuery): Promise<SessionStatsDailyResponse>
   accessPolicies(): Promise<AccessPolicy[]>
 
@@ -169,10 +179,12 @@ export interface BaseTequilapiClient {
 class BaseHttpTequilapiClient implements BaseTequilapiClient {
   public http: HttpInterface
   public readonly payment: PaymentAPI
+  public readonly provider: ProviderAPI
 
   public constructor(http: HttpInterface) {
     this.http = http
     this.payment = new PaymentAPI(http)
+    this.provider = new ProviderAPI(http)
   }
 
   public async healthCheck(timeout?: number): Promise<NodeHealthcheck> {
@@ -439,6 +451,9 @@ class BaseHttpTequilapiClient implements BaseTequilapiClient {
     return parseSessionListResponse(response)
   }
 
+  /**
+   * @deprecated use ProviderAPI
+   */
   public async sessionStatsAggregated(
     query?: SessionQuery
   ): Promise<SessionStatsAggregatedResponse> {
@@ -449,6 +464,9 @@ class BaseHttpTequilapiClient implements BaseTequilapiClient {
     return parseSessionStatsAggregatedResponse(response)
   }
 
+  /**
+   * @deprecated use ProviderAPI
+   */
   public async sessionStatsDaily(query?: SessionQuery): Promise<SessionStatsDailyResponse> {
     const response = await this.http.get('sessions/stats-daily', query)
     if (!response) {


### PR DESCRIPTION
It's next step in metric fetching. Generally we want to retain data between clean node re-installs and avoid discrepancies between two data sources (local and remote)

Signed-off-by: Mantas Domaševičius <mantas@mysterium.network>